### PR TITLE
feat/Add new functionalities to CSA 

### DIFF
--- a/commands/all.go
+++ b/commands/all.go
@@ -6,22 +6,19 @@ import (
 
 	"encoding/json"
 
+	"github.com/scalefast/talos/tools/csa"
 	"github.com/scalefast/talos/tools/dast"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
 
 type Settings struct {
-	Csa  CSA           `json:"csa" yaml:"CSA"`
+	Csa  csa.Settings  `json:"csa" yaml:"CSA"`
 	Dast dast.Settings `json:"dast" yaml:"DAST"`
 }
 
-type CSA struct {
-	Image string `json:"image" yaml:"Image"`
-}
-
 var cmdAll = &cobra.Command{
-	Use:   "all (--output [yaml|json])",
+	Use:   "all (--output [yaml|json]) (--filename name)",
 	Short: "Generate all config settings",
 	Long:  `Generate all config settings and output to a file for later use`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -50,6 +47,9 @@ var cmdAll = &cobra.Command{
 		} else {
 			fmt.Print("Filetype not supported. Must be yaml or json")
 		}
-		os.WriteFile("config.yaml", data, 0666)
+		err := os.WriteFile(filename, data, 0644)
+		if err != nil {
+			fmt.Printf("Error generating the file %v", err)
+		}
 	},
 }

--- a/commands/all.go
+++ b/commands/all.go
@@ -18,7 +18,7 @@ type Settings struct {
 }
 
 var cmdAll = &cobra.Command{
-	Use:   "all (--output [yaml|json]) (--filename name)",
+	Use:   "all (--format [yaml|json]) (--o Path)",
 	Short: "Generate all config settings",
 	Long:  `Generate all config settings and output to a file for later use`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -18,9 +18,9 @@ func Execute(version string) {
 	cmdCSA.Flags().StringVarP(&filename, "config", "c", "config.yaml", "Config file location, relative to binary")  // What handler handles file types in cobra?
 	cmdCSA.Flags().StringVarP(&network, "network", "n", "none", "Network to connect the container")
 	cmdCSA.Flags().StringVarP(&user, "user", "u", "root", "Username or UID to execute the container")
-	cmdCSA.Flags().StringVarP(&output, "filename", "f", "", "Path to store the analysis result")
+	cmdCSA.Flags().StringVarP(&output, "output", "o", "", "Path to store the analysis result")
 	cmdAll.Flags().StringVarP(&filetype, "format", "f", "yaml", "Config file format")
-	cmdAll.Flags().StringVarP(&filename, "output", "o", "", "Path to store the Config")
+	cmdAll.Flags().StringVarP(&filename, "config", "c", "config.yaml", "Path to store the Config")
 
 	// Execute sets-up the run command, so that any security analysis tools can be
 	// added after it.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -4,16 +4,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//Config file. Declare type
+// Config file. Declare type
 var filename string
 var filetype string
+var network string
+var user string
+var output string
 
 // Gets called with the version we want to have,
 // Now we want to print the version if it is required.
 func Execute(version string) {
 	cmdDAST.Flags().StringVarP(&filename, "config", "c", "config.yaml", "Config file location, relative to binary") // What handler handles file types in cobra?
 	cmdCSA.Flags().StringVarP(&filename, "config", "c", "config.yaml", "Config file location, relative to binary")  // What handler handles file types in cobra?
+	cmdCSA.Flags().StringVarP(&network, "network", "n", "none", "Network to connect the container")
+	cmdCSA.Flags().StringVarP(&user, "user", "u", "root", "Username or UID to execute the container")
+	cmdCSA.Flags().StringVarP(&output, "filename", "f", "", "Path to store the analysis result")
 	cmdAll.Flags().StringVarP(&filetype, "format", "f", "yaml", "Config file format")
+	cmdAll.Flags().StringVarP(&filename, "output", "o", "", "Path to store the Config")
 
 	// Execute sets-up the run command, so that any security analysis tools can be
 	// added after it.

--- a/commands/csa.go
+++ b/commands/csa.go
@@ -3,10 +3,10 @@ package commands
 import (
 	"os"
 
-	"github.com/spf13/cobra"
 	cfg "github.com/scalefast/talos/config"
 	logger "github.com/scalefast/talos/logger"
 	"github.com/scalefast/talos/tools/csa"
+	"github.com/spf13/cobra"
 )
 
 // cmdCSA is a global variable that contains the information needed for cobra to
@@ -28,6 +28,6 @@ var cmdCSA = &cobra.Command{
 		}
 		// Send the control, (along with the config, and logger) // Sergio's comment
 		// To the analyzer // Sergio's comment
-		csa.Analyze(c, l)
+		csa.Analyze(c, l, user, network, output)
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,8 +1,8 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
 	logger "github.com/scalefast/talos/logger"
+	"github.com/spf13/cobra"
 )
 
 // Base command to RUN.

--- a/config/config.go
+++ b/config/config.go
@@ -1,12 +1,40 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 func ParseConfig(config string) (*viper.Viper, error) {
 	v := viper.New()
-	v.AddConfigPath(".")
+	format, err := CheckFile(config)
+	if err != nil {
+		return v, err
+	}
+	v.SetConfigType(format)
 	v.SetConfigFile(config)
 	return v, v.ReadInConfig()
+}
+
+func CheckFile(config string) (viperFormat string, err error) {
+	fileContent, err := ioutil.ReadFile(config)
+	if err != nil {
+		fmt.Println("Error reading file: ", err)
+		return "", err
+	}
+
+	var checkfile interface{}
+	err = json.Unmarshal(fileContent, &checkfile)
+	if err == nil {
+		return "json", nil
+	}
+	err = yaml.Unmarshal(fileContent, &checkfile)
+	if err == nil {
+		return "yaml", nil
+	}
+	return "", fmt.Errorf("The file is not in JSON or YAML format")
 }

--- a/tools/csa/csa.go
+++ b/tools/csa/csa.go
@@ -83,7 +83,7 @@ func Analyze(c *viper.Viper, l *logger.StandardLogger, user string, network stri
 		l.ECustom("Error, could not create the file")
 		panic(err)
 	}
-	l.ICustom("Report saved to file report.txt")
+	l.ICustom("Report saved successfully")
 	stdcopy.StdCopy(f, os.Stderr, out)
 	defer f.Close()
 }

--- a/tools/csa/types.go
+++ b/tools/csa/types.go
@@ -1,0 +1,5 @@
+package csa
+
+type Settings struct {
+	Image string `json:"image" yaml:"Image"`
+}


### PR DESCRIPTION
Added:
- Config.go File in Absolute Path
- Add flags into csa command:
  - network (Choose the network that container will execute DEFAULT "none")
  - user (Choose the user to execute the container DEFAULT "root")
  - filename (Path to export the results)
- Flags in Gen All
  - output  (Path to export the config)
- Create types file in CSA
- Config.go Check file if its json or yaml 